### PR TITLE
SECKSD-1484 Provide parameter to acknowledge invalid hosts on security activation

### DIFF
--- a/bin/commands/activate.version.js
+++ b/bin/commands/activate.version.js
@@ -38,7 +38,7 @@ class ActivateVersionCommand {
       })
       .stringArray('--acknowledge-invalid-hosts <invalid hostnames>', {
         desc:
-          'A comma separated list of domains or subdomains that are listed in this configuration as protected, but which cannot be protected for some reason (for example, they are not managed by Akamai). If a previous activation response required you to acknowledge a list of invalid hosts, you can do so here.',
+          'In some cases, you may wish to activate a security configuration which targets hosts to which protection cannot be applied (for example, hosts not managed as Akamai properties). This will block activation with a warning, which will include the names of the invalid hosts. If you want to activate anyway, use this parameter to provide a comma-separated list of invalid host names to acknowledge the warning.',
         group: 'Options:',
         required: false
       });

--- a/bin/commands/activate.version.js
+++ b/bin/commands/activate.version.js
@@ -35,6 +35,12 @@ class ActivateVersionCommand {
         desc: 'The comma separated email ids to get notification.',
         group: 'Options:',
         required: true
+      })
+      .stringArray('--acknowledge-invalid-hosts <invalid hostnames>', {
+        desc:
+          'A comma separated list of domains or subdomains that are listed in this configuration as protected, but which cannot be protected for some reason (for example, they are not managed by Akamai). If a previous activation response required you to acknowledge a list of invalid hosts, you can do so here.',
+        group: 'Options:',
+        required: false
       });
   }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "child-process-promise": "^2.2.1",
-    "edgegrid": "^3.0.4",
+    "edgegrid": "^3.0.6",
     "pino": "^4.10.4",
     "string-format": "^0.5.0",
     "sywac": "^1.2.0",

--- a/src/activation.js
+++ b/src/activation.js
@@ -31,6 +31,9 @@ class Activation {
     if (this._options.notify) {
       activation.notificationEmails = this._options.notify;
     }
+    if (this._options['acknowledge-invalid-hosts']) {
+      activation['acknowledgedInvalidHosts'] = this._options['acknowledge-invalid-hosts'];
+    }
 
     return this._config
       .getConfigId()

--- a/templates/activation.json
+++ b/templates/activation.json
@@ -9,5 +9,6 @@
             "configId": -1,
             "configVersion": -1
         }
-    ]
+    ],
+    "acknowledgedInvalidHosts":[]
 }


### PR DESCRIPTION
See https://developer.akamai.com/api/cloud_security/application_security/v1.html#postactivations - acknowledgedInvalidHosts parameter, in schema